### PR TITLE
Add CPP-17687

### DIFF
--- a/freeze_rules/actions.py
+++ b/freeze_rules/actions.py
@@ -176,7 +176,8 @@ def get_rules():
                     "TargetElementUtil.findTargetElement"],
                    desc("Find Usages action finds target element on EDT")),
 
-
+        NormalRule(["intentions.OCConvertToPropertyIntentionAction.isAvailable"],
+                   desc("OCConvertToPropertyIntentionAction.isAvailable", bug="CPP-17687")),
 
     ]
     return rules


### PR DESCRIPTION
OCConvertToPropertyIntentionAction.isAvailable may lead resolve in EDT which lead freeze.
See https://youtrack.jetbrains.com/issue/CPP-17687